### PR TITLE
fixed bug at end of experiment

### DIFF
--- a/Code/trial.php
+++ b/Code/trial.php
@@ -133,6 +133,10 @@
     if( !isset( $minTime ) ) {
         $minTime    = 'not set';
     }
+    
+    
+    ob_start();
+    
 
     #### Presenting different trial types ####
     $expFiles  = $up.$expFiles;                            // setting relative path to experiments folder for trials launched from this page
@@ -144,8 +148,6 @@
     $title = 'Trial';
     $_dataController = 'trial';
     $_dataAction = $trialType;
-    
-    ob_start();
     
     
     /*


### PR DESCRIPTION
When last row of procedure was reached, the trial type was searched for, even though it was the EndOfExperiment line.  This was creating a small warning, which was preventing the redirect if buffering wasn't enabled.  So, I moved the opening of the buffer before that point.
