### PR TITLE
timer bug fix

### DIFF
--- a/Code/javascript/collector_1.0.0.js
+++ b/Code/javascript/collector_1.0.0.js
@@ -69,8 +69,6 @@ var COLLECTOR = {
 		function instance() {
 			var timeRemaining = goal - Date.now(),
 				timeFormatted;
-            
-            timeRemaining = Math.min(timeRemaining, 10000);
 
 			// stop timer at the allotted time
   			if (timeRemaining <= cap) {
@@ -91,7 +89,9 @@ var COLLECTOR = {
   					show.html( timeFormatted );
                 }
 				timeRemaining = Math.min( 20, timeRemaining );
-  			}
+  			} else {
+                timeRemaining = Math.min(timeRemaining, 10000);
+            }
 
 			if (timeRemaining <= lastWait) {
 				timeRemaining = cap;


### PR DESCRIPTION
When using the show functionality of the collector timer, the 10 second cap was making the clock show a cap of 10, even though show uses a 20ms cap anyways.  Moved the 10 second cap to an else statement of this, so they dont interfere.
