### PR TITLE
This fixes #79

### DIFF
--- a/Code/TrialTypes/FreeRecall.php
+++ b/Code/TrialTypes/FreeRecall.php
@@ -6,4 +6,3 @@
     <div class="textleft">
         <input class="button button-trial-advance" id="FormSubmitButton" type="submit" value="Submit"   />
     </div>
-    </form>


### PR DESCRIPTION
removes closing form tag from inside the trial type file, which was preventing the RT inputs generated by the main trial.php file from getting posted back to the server when the form was submitted.